### PR TITLE
TEMP: use makefile and test.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,6 @@ ENV LANG C.UTF-8
 ENV TEST_DEBUG=0
 
 WORKDIR /root/lightning-integration
+COPY Makefile /root/lightning-integration/Makefile
+COPY test.py /root/lightning-integration/test.py
 CMD ["make", "update", "clients", "test"]


### PR DESCRIPTION
This is a temporal fix for other PRs to base on.
The real fix should be https://github.com/jtimon/lightning-integration/pull/3